### PR TITLE
Work around warnings building Google Benchmark w/Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ macro(build_benchmark)
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
   include(ExternalProject)
+  find_package(Patch REQUIRED)
+
   externalproject_add(benchmark-1.5.1
     URL https://github.com/google/benchmark/archive/v1.5.1/benchmark-1.5.1.tar.gz
     URL_MD5 91d2d9a824cab82c67a80ccce5b93218
@@ -57,6 +59,8 @@ macro(build_benchmark)
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
+    PATCH_COMMAND
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/thread_safety_attributes.patch
+++ b/thread_safety_attributes.patch
@@ -1,0 +1,15 @@
+--- a/cmake/thread_safety_attributes.cpp	2020-07-15 17:35:35.557813957 -0700
++++ b/cmake/thread_safety_attributes.cpp	2020-07-15 17:36:19.040227189 -0700
+@@ -1,4 +1,12 @@
+ #define HAVE_THREAD_SAFETY_ATTRIBUTES
+ #include "../src/mutex.h"
+ 
++namespace benchmark
++{
++namespace internal
++{
++int InitializeStreams() { return 0; }
++}
++}
++
+ int main() {}


### PR DESCRIPTION
This should allow the HAVE_THREAD_SAFETY_ATTRIBUTES check to succeed and subsequently annotate the mutex functions properly and resolve the build warnings we're seeing in the clang/libcxx nightly builds.

Hopefully there will be an official fix for the issue soon.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11492)](http://ci.ros2.org/job/ci_linux/11492/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6688)](http://ci.ros2.org/job/ci_linux-aarch64/6688/)
* Linux-clang [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11494)](http://ci.ros2.org/job/ci_linux/11494/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9422)](http://ci.ros2.org/job/ci_osx/9422/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11381)](http://ci.ros2.org/job/ci_windows/11381/)