### PR TITLE
Set minimum criteria for system package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,15 @@ macro(build_benchmark)
   )
 endmacro()
 
-if(NOT benchmark_FOUND)
+if(NOT benchmark_FOUND OR "${benchmark_VERSION}" VERSION_LESS 1.5.0)
   build_benchmark()
+elseif(benchmark_FOUND)
+  # Ubuntu Focal has a packaging bug where libbenchmark_main has no symbols,
+  # causing linker failures. I'm pretty sure it shouldn't be a static library.
+  get_target_property(_benchmark_main_type benchmark::benchmark_main TYPE)
+  if(NOT "${_benchmark_main_type}" STREQUAL "SHARED_LIBRARY")
+    build_benchmark()
+  endif()
 endif()
 
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if(NOT benchmark_FOUND OR "${benchmark_VERSION}" VERSION_LESS 1.5.0)
 elseif(benchmark_FOUND)
   # Ubuntu Focal has a packaging bug where libbenchmark_main has no symbols,
   # causing linker failures. I'm pretty sure it shouldn't be a static library.
+  # Details: https://bugs.launchpad.net/ubuntu/+source/benchmark/+bug/1887872
   get_target_property(_benchmark_main_type benchmark::benchmark_main TYPE)
   if(NOT "${_benchmark_main_type}" STREQUAL "SHARED_LIBRARY")
     build_benchmark()


### PR DESCRIPTION
There are some features in 1.5.X that I think we'll want to leverage.

Also work around what I believe is a packaging bug in Ubuntu Eoan and newer. I'm not 100% certain, but I believe that libbenchmark_main doesn't work correctly when it's not a shared library.

https://bugs.launchpad.net/ubuntu/+source/benchmark/+bug/1887872

This means that right now, none of the supported platforms have an acceptable version of `benchmark` available as a system package.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11547)](http://ci.ros2.org/job/ci_linux/11547/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6710)](http://ci.ros2.org/job/ci_linux-aarch64/6710/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9446)](http://ci.ros2.org/job/ci_osx/9446/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11522)](http://ci.ros2.org/job/ci_windows/11522/)