### PR TITLE
adds qnx external project options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,10 @@ macro(build_benchmark)
   list(APPEND extra_cmake_args "-DBUILD_SHARED_LIBS=ON")
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    if(QNX)
+      # defined in toolchain file
+      set_qnx_external_project_options()
+    endif()
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
     if(ANDROID)
       if(DEFINED ANDROID_ABI)
@@ -50,7 +54,12 @@ macro(build_benchmark)
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
   include(ExternalProject)
-  find_package(Patch REQUIRED)
+
+  if(QNX)
+    find_host_package(Patch REQUIRED)
+  else()
+    find_package(Patch REQUIRED)
+  endif()
 
   externalproject_add(benchmark-1.5.1
     URL https://github.com/google/benchmark/archive/v1.5.1/benchmark-1.5.1.tar.gz


### PR DESCRIPTION
Fixes #4 
Fixes #6 

When cross compiling for QNX a toolchain file is provided to COLCON in addition to other command line arguments that are related to the architecture being built. Using cmake's externalproject_add() function, the value of the variables set from command line, outside the toolchain file, have to be re-passed to the external project by setting them again and including them in the extra_cmake_args variable. The macro set_qnx_external_project_options() implements this functionality.

in the tool chain file CMAKE_FIND_ROOT_PATH is set to only find_package() in the specific search paths provided for the intended architecture. Another macro find_host_package() had to be implemented in order to search for patch utility in the host file system. The macro find_host_package() is defined in the toolchain file.