### PR TITLE
Set the SOVERSION on benchmark libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,15 @@ endif()
 macro(build_benchmark)
   set(extra_cmake_args)
 
+  set(GOOGLE_BENCHMARK_TARGET_VERSION "1.5.1")
+
   if(DEFINED CMAKE_BUILD_TYPE)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   endif()
 
   list(APPEND extra_cmake_args "-DBENCHMARK_ENABLE_TESTING=OFF")
   list(APPEND extra_cmake_args "-DBUILD_SHARED_LIBS=ON")
+  list(APPEND extra_cmake_args "-DGIT_VERSION=\"${GOOGLE_BENCHMARK_TARGET_VERSION}\"")
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
     list(APPEND extra_cmake_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
@@ -52,15 +55,16 @@ macro(build_benchmark)
   include(ExternalProject)
   find_package(Patch REQUIRED)
 
-  externalproject_add(benchmark-1.5.1
-    URL https://github.com/google/benchmark/archive/v1.5.1/benchmark-1.5.1.tar.gz
+  externalproject_add(benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}
+    URL "https://github.com/google/benchmark/archive/v${GOOGLE_BENCHMARK_TARGET_VERSION}/benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}.tar.gz"
     URL_MD5 91d2d9a824cab82c67a80ccce5b93218
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
     PATCH_COMMAND
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch &&
+      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/soversion.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/soversion.patch
+++ b/soversion.patch
@@ -1,0 +1,11 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -79,7 +79,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_C
+
+ # Read the git tags to determine the project version
+ include(GetGitVersion)
+-get_git_version(GIT_VERSION)
++#get_git_version(GIT_VERSION)
+
+ # Tell the user what versions we are using
+ string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" VERSION ${GIT_VERSION})


### PR DESCRIPTION
The built-in logic for detecting the SOVERSION on the shared libraries requires that the sources are in a tagged git repository, but we're downloading a tarball. If we disable the git tag extraction and manually specify the version that we downloaded, the SOVERSION is correct.

Both Ubuntu and Fedora benchmark packages work around the SOVERSION in this way.