### PR TITLE
Update the patching to work on Windows without admin.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ macro(build_benchmark)
   list(APPEND extra_cmake_args "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
   include(ExternalProject)
-  find_package(Patch REQUIRED)
 
   externalproject_add(benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}
     URL "https://github.com/google/benchmark/archive/v${GOOGLE_BENCHMARK_TARGET_VERSION}/benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}.tar.gz"
@@ -63,8 +62,8 @@ macro(build_benchmark)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
     PATCH_COMMAND
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch &&
-      ${Patch_EXECUTABLE} -p1 -N < ${CMAKE_CURRENT_SOURCE_DIR}/soversion.patch
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch &&
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/soversion.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,8 +55,12 @@ macro(build_benchmark)
   include(ExternalProject)
 
   externalproject_add(benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}
-    URL "https://github.com/google/benchmark/archive/v${GOOGLE_BENCHMARK_TARGET_VERSION}/benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}.tar.gz"
-    URL_MD5 084b34aceaeac11a6607d35220ca2efa
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v${GOOGLE_BENCHMARK_TARGET_VERSION}
+    GIT_CONFIG advice.detachedHead=false
+    # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
+    # See https://github.com/ament/uncrustify_vendor/pull/22 for details
+    UPDATE_COMMAND ""
     TIMEOUT 600
     CMAKE_ARGS
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install

--- a/soversion.patch
+++ b/soversion.patch
@@ -1,11 +1,13 @@
---- a/CMakeLists.txt
-+++ b/CMakeLists.txt
-@@ -79,7 +79,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_C
-
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index db0a6bfb..26ccf1a5 100644
+--- a/CMakeLists.txt	2020-07-15 17:35:35.557813957 -0700
++++ b/CMakeLists.txt	2020-07-15 17:36:19.040227189 -0700
+@@ -79,7 +79,7 @@
+ 
  # Read the git tags to determine the project version
  include(GetGitVersion)
 -get_git_version(GIT_VERSION)
 +#get_git_version(GIT_VERSION)
-
+ 
  # Tell the user what versions we are using
  string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" VERSION ${GIT_VERSION})

--- a/thread_safety_attributes.patch
+++ b/thread_safety_attributes.patch
@@ -1,3 +1,5 @@
+diff --git a/cmake/thread_safety_attributes.cpp b/cmake/thread_safety_attributes.cpp
+index db0a6bfb..26ccf1a5 100644
 --- a/cmake/thread_safety_attributes.cpp	2020-07-15 17:35:35.557813957 -0700
 +++ b/cmake/thread_safety_attributes.cpp	2020-07-15 17:36:19.040227189 -0700
 @@ -1,4 +1,12 @@


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Like we've done elsewhere, update `google_benchmark_vendor` to use `git apply` for applying patches.  This allows it to work on Windows without administrator.

@cottsay Note that I did not change this to use `git` to fetch the sources as we did in `uncrustify_vendor`.  It seemed to work without problems for me on all of Linux, Windows, and macOS without that.  Nevertheless, I'd appreciate your insight here into whether I should change this to use `GIT_REPOSITORY` instead.