### PR TITLE
Use git hash for google_benchmark_vendor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ macro(build_benchmark)
 
   externalproject_add(benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG v${GOOGLE_BENCHMARK_TARGET_VERSION}
+    GIT_TAG c05843a9f622db08ad59804c190f98879b76beba  # v${GOOGLE_BENCHMARK_TARGET_VERSION}
     GIT_CONFIG advice.detachedHead=false
     # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
     # See https://github.com/ament/uncrustify_vendor/pull/22 for details


### PR DESCRIPTION
CMake ExternalProject_add recommends using a specific git hash with
GIT_TAG because branches and tags can be updated to point to different
references.

https://cmake.org/cmake/help/latest/module/ExternalProject.html

Signed-off-by: Shane Loretz <sloretz@osrfoundation.org>