### PR TITLE
Add git buildtool dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <author email="scott@openrobotics.org">Scott K Logan</author>
 
   <buildtool_depend>cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <depend>benchmark</depend>
 


### PR DESCRIPTION
Since we normally install git as part of our regular development workflow this build tool dependency is often overlooked. However doing cursed things with containers I stumbled upon the need for git during the build stage.