### PR TITLE
Remove set but unused variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ macro(build_benchmark)
     PATCH_COMMAND
       ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
         ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
-        ${CMAKE_CURRENT_SOURCE_DIR}/unused_variable.patch
+        ${CMAKE_CURRENT_SOURCE_DIR}/e991355c02b93fe17713efe04cbc2e278e00fdbd.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ macro(build_benchmark)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
     PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
+      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn
+        ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
+        ${CMAKE_CURRENT_SOURCE_DIR}/unused_variable.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.

--- a/e991355c02b93fe17713efe04cbc2e278e00fdbd.patch
+++ b/e991355c02b93fe17713efe04cbc2e278e00fdbd.patch
@@ -1,5 +1,16 @@
+From e991355c02b93fe17713efe04cbc2e278e00fdbd Mon Sep 17 00:00:00 2001
+From: Roman Lebedev <lebedev.ri@gmail.com>
+Date: Wed, 9 Jun 2021 11:52:12 +0300
+Subject: [PATCH] [NFCI] Drop warning to satisfy clang's
+ -Wunused-but-set-variable diag (#1174)
+
+Fixes https://github.com/google/benchmark/issues/1172
+---
+ src/complexity.cc | 2 --
+ 1 file changed, 2 deletions(-)
+
 diff --git a/src/complexity.cc b/src/complexity.cc
-index aeed67f..79e00c6 100644
+index d74b14692..29f7c3b03 100644
 --- a/src/complexity.cc
 +++ b/src/complexity.cc
 @@ -82,7 +82,6 @@ std::string GetBigOString(BigO complexity) {

--- a/unused_variable.patch
+++ b/unused_variable.patch
@@ -1,0 +1,20 @@
+diff --git a/src/complexity.cc b/src/complexity.cc
+index aeed67f..79e00c6 100644
+--- a/src/complexity.cc
++++ b/src/complexity.cc
+@@ -82,7 +82,6 @@ std::string GetBigOString(BigO complexity) {
+ LeastSq MinimalLeastSq(const std::vector<int64_t>& n,
+                        const std::vector<double>& time,
+                        BigOFunc* fitting_curve) {
+-  double sigma_gn = 0.0;
+   double sigma_gn_squared = 0.0;
+   double sigma_time = 0.0;
+   double sigma_time_gn = 0.0;
+@@ -90,7 +89,6 @@ LeastSq MinimalLeastSq(const std::vector<int64_t>& n,
+   // Calculate least square fitting parameter
+   for (size_t i = 0; i < n.size(); ++i) {
+     double gn_i = fitting_curve(n[i]);
+-    sigma_gn += gn_i;
+     sigma_gn_squared += gn_i * gn_i;
+     sigma_time += time[i];
+     sigma_time_gn += time[i] * gn_i;


### PR DESCRIPTION
Clang checks -Wunused-but-set-variable.
This fails the build with -Werror also enabled.

This fix is also included in v1.6.2 in upstream: https://github.com/google/benchmark/commit/e991355c02b93fe17713efe04cbc2e278e00fdbd

Signed-off-by: Michael Carroll <michael@openrobotics.org>