### PR TITLE
Resolve Clang compilation issue with benchmark 1.5.3

### DIFF
--- a/0001-NFCI-Drop-warning-to-satisfy-clang-s-Wunused-but-set.patch
+++ b/0001-NFCI-Drop-warning-to-satisfy-clang-s-Wunused-but-set.patch
@@ -1,0 +1,34 @@
+From e991355c02b93fe17713efe04cbc2e278e00fdbd Mon Sep 17 00:00:00 2001
+From: Roman Lebedev <lebedev.ri@gmail.com>
+Date: Wed, 9 Jun 2021 11:52:12 +0300
+Subject: [PATCH] [NFCI] Drop warning to satisfy clang's
+ -Wunused-but-set-variable diag (#1174)
+
+Fixes https://github.com/google/benchmark/issues/1172
+---
+ src/complexity.cc | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/complexity.cc b/src/complexity.cc
+index d74b146..29f7c3b 100644
+--- a/src/complexity.cc
++++ b/src/complexity.cc
+@@ -82,7 +82,6 @@ std::string GetBigOString(BigO complexity) {
+ LeastSq MinimalLeastSq(const std::vector<int64_t>& n,
+                        const std::vector<double>& time,
+                        BigOFunc* fitting_curve) {
+-  double sigma_gn = 0.0;
+   double sigma_gn_squared = 0.0;
+   double sigma_time = 0.0;
+   double sigma_time_gn = 0.0;
+@@ -90,7 +89,6 @@ LeastSq MinimalLeastSq(const std::vector<int64_t>& n,
+   // Calculate least square fitting parameter
+   for (size_t i = 0; i < n.size(); ++i) {
+     double gn_i = fitting_curve(n[i]);
+-    sigma_gn += gn_i;
+     sigma_gn_squared += gn_i * gn_i;
+     sigma_time += time[i];
+     sigma_time_gn += time[i] * gn_i;
+-- 
+2.34.1
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 macro(build_benchmark)
   set(extra_cmake_args)
 
-  set(GOOGLE_BENCHMARK_TARGET_VERSION "1.6.1")
+  set(GOOGLE_BENCHMARK_TARGET_VERSION "1.5.3")
 
   if(DEFINED CMAKE_BUILD_TYPE)
     list(APPEND extra_cmake_args -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
@@ -56,7 +56,7 @@ macro(build_benchmark)
 
   externalproject_add(benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG 0d98dba29d66e93259db7daa53a9327df767a415  # v${GOOGLE_BENCHMARK_TARGET_VERSION}
+    GIT_TAG c05843a9f622db08ad59804c190f98879b76beba  # v${GOOGLE_BENCHMARK_TARGET_VERSION}
     GIT_CONFIG advice.detachedHead=false
     # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
     # See https://github.com/ament/uncrustify_vendor/pull/22 for details
@@ -66,7 +66,8 @@ macro(build_benchmark)
       -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_install
       ${extra_cmake_args}
     PATCH_COMMAND
-      ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
+      COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/thread_safety_attributes.patch
+      COMMAND ${CMAKE_COMMAND} -E chdir <SOURCE_DIR> git apply -p1 --ignore-space-change --whitespace=nowarn ${CMAKE_CURRENT_SOURCE_DIR}/0001-NFCI-Drop-warning-to-satisfy-clang-s-Wunused-but-set.patch
   )
 
   # The external project will install to the build folder, but we'll install that on make install.
@@ -79,7 +80,7 @@ macro(build_benchmark)
   )
 endmacro()
 
-if(NOT benchmark_FOUND OR "${benchmark_VERSION}" VERSION_LESS 1.6.1)
+if(NOT benchmark_FOUND OR "${benchmark_VERSION}" VERSION_LESS 1.5.3)
   build_benchmark()
 elseif(benchmark_FOUND)
   # Ubuntu Focal and Jammy have a packaging bug where libbenchmark_main has no symbols,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ macro(build_benchmark)
 
   externalproject_add(benchmark-${GOOGLE_BENCHMARK_TARGET_VERSION}
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG c05843a9f622db08ad59804c190f98879b76beba  # v${GOOGLE_BENCHMARK_TARGET_VERSION}
+    GIT_TAG 0d98dba29d66e93259db7daa53a9327df767a415  # v${GOOGLE_BENCHMARK_TARGET_VERSION}
     GIT_CONFIG advice.detachedHead=false
     # Suppress git update due to https://gitlab.kitware.com/cmake/cmake/-/issues/16419
     # See https://github.com/ament/uncrustify_vendor/pull/22 for details


### PR DESCRIPTION
Would like to upgrade to latest version of Google Benchmark 1.6.1 to resolve this issue that shows up when generating release builds:

``` bash
Cloning into 'benchmark-1.6.1'...
HEAD is now at c05843a [sysinfo] Fix CPU Frequency reading on AMD Ryzen CPU's (#1117)
/home/adam/Documents/r2/build/release/google_benchmark_vendor/benchmark-1.6.1-prefix/src/benchmark-1.6.1/src/complexity.cc:85:10: error: variable 'sigma_gn' set but not used [-Werror,-Wunused-but-set-variable]
  double sigma_gn = 0.0;
         ^
1 error generated.
gmake[5]: *** [src/CMakeFiles/benchmark.dir/build.make:174: src/CMakeFiles/benchmark.dir/complexity.cc.o] Error 1
gmake[5]: *** Waiting for unfinished jobs....
gmake[4]: *** [CMakeFiles/Makefile2:100: src/CMakeFiles/benchmark.dir/all] Error 2
gmake[3]: *** [Makefile:136: all] Error 2
gmake[2]: *** [CMakeFiles/benchmark-1.6.1.dir/build.make:86: benchmark-1.6.1-prefix/src/benchmark-1.6.1-stamp/benchmark-1.6.1-build] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/benchmark-1.6.1.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
---
Failed   <<< google_benchmark_vendor [10.7s, exited with code 2]

Summary: 0 packages finished [11.3s]
  1 package failed: google_benchmark_vendor
  1 package had stderr output: google_benchmark_vendor
```
I've confirmed this is resolved with the [latest 1.6.1 version](https://github.com/google/benchmark/blob/0d98dba29d66e93259db7daa53a9327df767a415/src/complexity.cc#L86) but the older version referenced in the cmake does contain [this erroneous variable](https://github.com/google/benchmark/blob/c05843a9f622db08ad59804c190f98879b76beba/src/complexity.cc#L85C25-L85C25).